### PR TITLE
Allow README examples to be copy/paste-able

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ Now that we're storing state, we need a way to query our topology. To do that, w
 In our `level-eight-evil-topology`, we'll be creating a `LocalDRPC`, and querying our stateful topology in-process using Marceline's `state-query`. For remote topology submission, just use `nil` instead of the `LocalDRPC`.
 
 ```clojure
-(import '[backtype.storm LocalDRPC])
-(import '[storm.trident.operation.builtin MapGet])
+(import '[backtype.storm LocalDRPC]
+        '[storm.trident.operation.builtin MapGet])
 
 (defn build-topology [spout drpc]
   (let [word-state-factory (MemoryMapState$Factory.)
@@ -261,6 +261,7 @@ You can run this function and see it's outputs like this:
 
 ```clojure
 (def results (run-local! "evil vessel ogdoad"))
+;; storm will output a lot of messages
 results
 ;; ==> [["evil", null] ["vessel", 172] ["ogdoad", 172]] 
 


### PR DESCRIPTION
When going through the README I found that I had to modify the code a bit to get it to work.  So here are the changes I've made to allow you just to copy/paste from the README.

Also, I've modified run-local! to return the result of the DRPC.  I found that helpful to ensure that the topology and DRPC are working properly as well as it allowed me to play around with different inputs and see their respective results.
