### PR TITLE
Add partition-persist arity which allows out-fields

### DIFF
--- a/src/clj/marceline/storm/trident.clj
+++ b/src/clj/marceline/storm/trident.clj
@@ -367,11 +367,17 @@
   (.batchGlobal stream))
 
 (defn partition-persist
-  [stream state-spec in-fields state-updater]
-  (.partitionPersist stream
-                     state-spec
-                     (apply fields in-fields)
-                     state-updater))
+  ([stream state-spec in-fields state-updater]
+    (.partitionPersist stream
+                       state-spec
+                       (apply fields in-fields)
+                       state-updater))
+  ([stream state-spec in-fields state-updater out-fields]
+    (.partitionPersist stream
+                       state-spec
+                       (apply fields in-fields)
+                       state-updater
+                       (apply fields out-fields))))
 
 (defn persistent-aggregate
   ([stream state fn-inst fn-fields]


### PR DESCRIPTION
It's possible to perform a partitionPersist operation and emit tuples (defined by out-fields) which are then available with topology.newValuesStream.

That arity is currenty missing from the DSL.