### PR TITLE
bring defreduceraggregator inline with other aggregators

### DIFF
--- a/src/clj/marceline/storm/trident.clj
+++ b/src/clj/marceline/storm/trident.clj
@@ -177,11 +177,13 @@
     `(reify storm.trident.operation.ReducerAggregator
        ~@fns)))
 
-(defmacro defreduceraggregator [name & [opts impl :as all]]
+(defmacro defreduceraggregator [name & [opts & [init-impl reduce-impl] :as all]]
   (if-not (map? opts)
     `(defreduceraggregator ~name {} ~@all)
     (let [params (:params opts)
           fn-name (symbol (str name "__"))
+          [init-args & init-body] init-impl
+          [reduce-args & reduce-body] reduce-impl
           definer (if params
                     `(defn ~name [& args#]
                        (clojure-reducer-aggregator ~fn-name args#))
@@ -189,7 +191,9 @@
                        (clojure-reducer-aggregator ~fn-name [])))]
       `(do
          (defn ~fn-name ~(if params params [])
-           ~impl)
+           (reducer-aggregator
+             (~'init ~(vec init-args) ~@init-body)
+             (~'reduce ~(vec reduce-args) ~@reduce-body)))
          ~definer))))
 
 ;; ## queryfn


### PR DESCRIPTION
This brings defreduceraggregator macro inline with the style of the other aggregator macros.

As an aside, I think ClojureReducerAggregator should probably extend Aggregator rather than implement ReducerAggregator (a little like ReducerAggregatorImpl), then would naturally be an Operation and have access to the prepare lifecycle like the other trident operations / dsl macros.

At the moment ReducerAggregator prepares in constructor (I'm not entirely sure that's safe since operations are constructed and then serialized? Perhaps aggregation being a non-partitioned operation it's ok and the operation is always on the node it is constructed on), and CombinerAggregator prepares every time it attempts any actions, combiner is a little more complicated but think could follow the Impl approach in both cases. 

Apologies if I've missed some reasoning behind the current behavior.