### PR TITLE
Add support for to-stream to trident DSL

### DIFF
--- a/src/clj/marceline/storm/trident.clj
+++ b/src/clj/marceline/storm/trident.clj
@@ -394,6 +394,10 @@
   [stream group-fields]
   (.groupBy stream (apply fields group-fields)))
 
+(defn to-stream
+  [stream]
+  (.toStream stream))
+
 (defn partition-by
   [stream group-fields]
   (.partitionBy stream (apply fields group-fields)))


### PR DESCRIPTION
Currently missing, useful for turning a grouped stream back into a normal one - particularly if you've grouped, then used partition-aggregate, then want to project (or some other action not supported by grouped streams).